### PR TITLE
feat: Add token-based authentication to OpenFGA client

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ For Docker-based setups mount or copy the jar to
 ## Module Configuration
 The following properties can be set via environment variables following the Keycloak specs, thus each variable MUST use the prefix `KC_SPI_EVENTS_LISTENER_OPENFGA_EVENTS_PUBLISHER`.
 
-* `KC_SPI_EVENTS_LISTENER_OPENFGA_EVENTS_PUBLISHER_API_URL`: The `openfgaApiUrl` is the URI of the OpenFGA Server. If this variable is empty, the extension will use the default value `http://openfga:8080` for demo purposes only.
-
-* Optional `KC_SPI_EVENTS_LISTENER_OPENFGA_EVENTS_PUBLISHER__STORE_ID` and `KC_SPI_EVENTS_LISTENER_OPENFGA_EVENTS_PUBLISHER_AUTHORIZATION_MODEL_ID` : The `openfgaStoreId` and the `openfgaAuthorizationModelId`  are the store and authorization model identifiers in the OpenFGA server. If not provided, the extension will attempt to discovery them.
+* `KC_SPI_EVENTS_LISTENER_OPENFGA_EVENTS_PUBLISHER_OPENFGA_API_URL`: The `openfgaApiUrl` is the URI of the OpenFGA Server. If this variable is empty, the extension will use the default value `http://openfga:8080` for demo purposes only.
+* Optional `KC_SPI_EVENTS_LISTENER_OPENFGA_EVENTS_PUBLISHER_OPENFGA_STORE_ID` and `KC_SPI_EVENTS_LISTENER_OPENFGA_EVENTS_PUBLISHER_OPENFGA_AUTHORIZATION_MODEL_ID`: The `openfgaStoreId` and the `openfgaAuthorizationModelId`  are the store and authorization model identifiers in the OpenFGA server. If not provided, the extension will attempt to discovery them.
+* Optional `KC_SPI_EVENTS_LISTENER_OPENFGA_EVENTS_PUBLISHER_OPENFGA_API_TOKEN`: The `openfgaApiToken` to authenticate with the OpenFGA server.
 
 You may want to check [docker-compose.yml](docker-compose.yml) as an example.
 

--- a/src/main/java/com/twogenidentity/keycloak/service/OpenFgaClientHandler.java
+++ b/src/main/java/com/twogenidentity/keycloak/service/OpenFgaClientHandler.java
@@ -3,8 +3,10 @@ package com.twogenidentity.keycloak.service;
 import com.twogenidentity.keycloak.utils.OpenFgaHelper;
 import dev.openfga.sdk.api.client.OpenFgaClient;
 import dev.openfga.sdk.api.client.model.ClientWriteRequest;
+import dev.openfga.sdk.api.configuration.ApiToken;
 import dev.openfga.sdk.api.configuration.ClientConfiguration;
 import dev.openfga.sdk.api.configuration.ClientWriteOptions;
+import dev.openfga.sdk.api.configuration.Credentials;
 import dev.openfga.sdk.api.model.*;
 import dev.openfga.sdk.errors.FgaInvalidParameterException;
 import com.twogenidentity.keycloak.event.EventParser;
@@ -24,9 +26,10 @@ public class OpenFgaClientHandler {
 
     private final ClientWriteOptions clientWriteOptions;
 
-    protected static final String OPENFGA_API_URL = "openfgaApiUrl";
-    protected static final String OPENFGA_STORE_ID = "openfgaStoreId";
-    protected static final String OPENFGA_AUTHORIZATION_MODEL_ID = "openfgaAuthorizationModelId";
+    protected static final String OPENFGA_API_URL = "openfga-api-url";
+    protected static final String OPENFGA_API_TOKEN = "openfga-api-token";
+    protected static final String OPENFGA_STORE_ID = "openfga-store-id";
+    protected static final String OPENFGA_AUTHORIZATION_MODEL_ID = "openfga-authorization-model-id";
 
     private static final Logger LOG = Logger.getLogger(OpenFgaClientHandler.class);
 
@@ -37,6 +40,13 @@ public class OpenFgaClientHandler {
                 .apiUrl(getOpenFgaApiUrl())
                 .connectTimeout(Duration.ofSeconds(5))
                 .readTimeout(Duration.ofSeconds(5));
+
+        if(StringUtil.isNotBlank(getOpenFgaApiToken())) {
+            LOG.info("API Token provided in config, will use it for authentication with OpenFGA");
+            ApiToken token = new ApiToken(getOpenFgaApiToken());
+            Credentials credentials = new Credentials(token);
+            configuration.credentials(credentials);
+        }
 
         if(StringUtil.isNotBlank(getOpenFgaOpenStoreId())
                 && StringUtil.isNotBlank(getOpenFgaAuthorizationModelId())) {
@@ -85,6 +95,10 @@ public class OpenFgaClientHandler {
 
     public String getOpenFgaApiUrl() {
         return config.get(OPENFGA_API_URL) != null ? config.get(OPENFGA_API_URL) : "http://openfga:8080";
+    }
+
+    public String getOpenFgaApiToken() {
+        return config.get(OPENFGA_API_TOKEN) != null ? config.get(OPENFGA_API_TOKEN) : "";
     }
 
     public String getOpenFgaOpenStoreId() {


### PR DESCRIPTION
Closes #5.

I had to change the environment variables format to make them work in my setup. I'm using Keycloak 26.2, so I don't know if there was a Keycloak update in the way extensions should declare environment variables, but in this version, I had to make those changes to reach a working solution.